### PR TITLE
CI/CD - Enable gem publishing

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -13,8 +13,8 @@ slack:
   notify_channel: inspec-notify
 
 # This publish is triggered by the `built_in:publish_rubygems` artifact_action.
-# rubygems:
-#   - train-alicloud
+rubygems:
+  - train-alicloud
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch
@@ -27,9 +27,9 @@ github:
   # allow bumping the major release via label
   major_bump_labels:
     - "Expeditor: Bump Version Major"
- 
-# changelog:
-#   rollup_header: Changes not yet released to rubygems.org
+
+changelog:
+  rollup_header: Changes not yet released to rubygems.org
 
 # These actions are taken, in the order they are specified, anytime a Pull Request is merged.
 merge_actions:
@@ -48,7 +48,7 @@ merge_actions:
       only_if:
         - built_in:bump_version
 
-# promote:
-#   actions:
-#     - built_in:rollover_changelog
-#     - built_in:publish_rubygems
+promote:
+  actions:
+    - built_in:rollover_changelog
+    - built_in:publish_rubygems

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,12 +1,9 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
-
-# DISABLE PIPELINE until repo is public
-# chef-oss Buildkite org does not have access to private repos
-# pipelines:
-#   - verify:
-#       description: Pull Request validation tests
-#       public: true
+pipelines:
+  - verify:
+      description: Pull Request validation tests
+      public: true
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 .bundle
 vendor
 .envrc
+*.gem

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,1 +1,0 @@
-# CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# CHANGELOG
+
+<!-- latest_release 0.0.2 -->
+<!-- latest_release -->
+
+<!-- release_rollup since=0.0.2 -->
+### Changes not yet released to rubygems.org
+<!-- release_rollup -->
+
+<!-- latest_stable_release -->
+## [v0.0.2](https://github.com/inspec/train-alicloud/tree/v0.0.2) (2020-11-09)
+
+#### Merged Pull Requests
+- Initial release [#5](https://github.com/inspec/train-alicloud/pull/5) ([gsreynolds](https://github.com/gsreynolds))
+<!-- latest_stable_release -->
+
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You will need InSpec v2.3 or later.
 Simply run:
 
 ```
-$ bundle exec inspec plugin install ../train-alicloud/
+$ bundle exec inspec plugin install train-alicloud
 ```
 
 You can then run:


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

### Description

Enables gem publishing in the CI/CD system.

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
