### PR TITLE
support ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,11 @@ gem "train-core", "~> 3.0"
 gem "aliyunsdkcore"
 gem "aliyun-sdk"
 
+if Gem.ruby_version.to_s.start_with?("2.5")
+  # 16.7.23 required ruby 2.6+
+  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
+end
+
 group :development do
   gem "pry"
   gem "bundler"


### PR DESCRIPTION
support ruby 2.5

Signed-off-by: Sathish <sbabu@progress.com>

### Description

chef-utils > 16.7.23 dropped support for ruby 2.5 so we override & use older dependency to support the same

### Issues Resolved
allows support for ruby-2.5

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [ ] All Integration Tests pass
- [ ] All Unit Tests pass
- [ ] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
