### PR TITLE
Fix activesupport pin for Ruby <2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ if Gem.ruby_version.to_s.start_with?("2.5")
   gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
 end
 
+if Gem.ruby_version < Gem::Version.new("2.7.0")
+  gem "activesupport", "6.1.4.4"
+end
+
 group :development do
   gem "pry"
   gem "bundler"


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

This PR pins activesupport to a supported version when running with Ruby < 2.7

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List
Please fill box or appropriate ([x]) or mark N/A.
- [ ] New functionality includes integration tests/controls
- [ ] New Terraform resources
- [ ] Documentation provided or updated for resources 
- [X] All Integration Tests pass
- [X] All Unit Tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
